### PR TITLE
Fixes #4: Add new display option: short numbers

### DIFF
--- a/web/functions.php
+++ b/web/functions.php
@@ -68,3 +68,30 @@ function getShieldURL($query, $defaults)
     // Build the Shields.io url using the above parameters and JSON query
     return "https://img.shields.io/badge/dynamic/json?" . http_build_query($params);
 }
+
+// formats response subscriber count according to chosen format
+function formatSubscribers($response, $format) {
+    switch ($format) {
+        case "commas":
+            // Adding Commas
+            preg_match_all('!\d+!', strip_tags($response), $matches);
+            return str_replace($matches[0][0], number_format($matches[0][0]), $response);
+        case "short":
+            // shortening number
+            preg_match_all('!\d+!', strip_tags($response), $matches);
+            return str_replace($matches[0][0], shortNumber($matches[0][0]), $response);
+        case "none"; // fallthrough
+        default:
+            return $response;
+    }
+}
+
+// rounds a number to first decimal point and adds appropriate label for amount
+function shortNumber($num)
+{
+    $units = ['', 'k', 'm', 'b', 't'];
+    for ($i = 0; $num >= 1000; $i++) {
+        $num /= 1000;
+    }
+    return round($num, 1) . $units[$i];
+}

--- a/web/functions.php
+++ b/web/functions.php
@@ -69,8 +69,8 @@ function getShieldURL($query, $defaults)
     return "https://img.shields.io/badge/dynamic/json?" . http_build_query($params);
 }
 
-// formats response subscriber count according to chosen format
-function formatSubscribers($response, $format) {
+// formats response number according to chosen format
+function formatResponseNumber($response, $format) {
     switch ($format) {
         case "commas":
             // Adding Commas

--- a/web/subscribers/index.php
+++ b/web/subscribers/index.php
@@ -27,8 +27,8 @@ header('Content-type: image/svg+xml');
 // Get response from the URL and output its contents
 $response = curl_get_contents($url);
 
-// get format param and format the subscribers accordingly
+// get format param and format the subscriber count accordingly
 $format = validateParam("format", "/^(commas|short|none)$/", $defaults);
-$response = formatSubscribers($response, $format);
+$response = formatResponseNumber($response, $format);
 
 echo $response;

--- a/web/subscribers/index.php
+++ b/web/subscribers/index.php
@@ -8,6 +8,7 @@ $defaults = [
     "logo" => "youtube",
     "logoColor" => "white",
     "style" => "flat-square",
+    "format" => "short",
     "label" => "YouTube subscribers",
     "labelColor" => "gray",
     "id" => "UCipSxT7a3rn81vGLw9lqRkg",
@@ -26,8 +27,8 @@ header('Content-type: image/svg+xml');
 // Get response from the URL and output its contents
 $response = curl_get_contents($url);
 
-//Adding Commas 
-preg_match_all('!\d+!', strip_tags($response), $matches);
-$response =  str_replace($matches[0][0], number_format($matches[0][0]), $response);
+// get format param and format the subscribers accordingly
+$format = validateParam("format", "/^(commas|short|none)$/", $defaults);
+$response = formatSubscribers($response, $format);
 
 echo $response;

--- a/web/views/index.php
+++ b/web/views/index.php
@@ -8,6 +8,7 @@ $defaults = [
     "logo" => "youtube",
     "logoColor" => "white",
     "style" => "flat-square",
+    "format" => "short",
     "label" => "YouTube view count",
     "labelColor" => "gray",
     "id" => "UCipSxT7a3rn81vGLw9lqRkg",
@@ -26,8 +27,8 @@ header('Content-type: image/svg+xml');
 // Get response from the URL and output its contents
 $response = (curl_get_contents($url));
 
-//Adding Commas 
-preg_match_all('!\d+!', strip_tags($response), $matches);
-$response =  str_replace($matches[0][0], number_format($matches[0][0]), $response);
+// get format param and format the view count accordingly
+$format = validateParam("format", "/^(commas|short|none)$/", $defaults);
+$response = formatResponseNumber($response, $format);
 
 echo $response;


### PR DESCRIPTION
Introduces new url parameter "format".

format can have 3 possible values: "commas", "short" or "none. Fallback value is "short" if nothing else matches the given url parameter.

@DenverCoder1 I'm not 100% sure the regex for format catches all cases. I tested it with a few and it worked for those, but there might be some where it fails.